### PR TITLE
chore: fix indirect dependencies with go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/nikita-shtimenko/goconfig
 go 1.24.2
 
 require (
-	github.com/caarlos0/env/v11 v11.3.1 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
+	github.com/caarlos0/env/v11 v11.3.1
+	github.com/joho/godotenv v1.5.1
 )


### PR DESCRIPTION
## What
Run `go mod tidy` to fix indirect dependency declarations.

## Why
Some dependencies were marked as indirect when they should be direct, causing IDE warnings and potential build issues.

## Changes
- Updated `go.mod` 
- Updated `go.sum`

## Testing
- [x] `go mod verify` passes
- [x] All existing tests still pass